### PR TITLE
Fix embed dependencies handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 plugins {
     id 'java-library'
     id 'maven-publish'
@@ -38,13 +36,6 @@ dependencies {
     }
     api "org.bstats:bstats-bukkit:2.2.1"
     api 'org.apache.commons:commons-lang3:3.12.0'
-}
-
-processResources {
-    duplicatesStrategy DuplicatesStrategy.INCLUDE
-    from(sourceSets.main.resources.srcDirs) {
-        filter ReplaceTokens, tokens: [version: version]
-    }
 }
 
 publishing {


### PR DESCRIPTION
For embed dependencies, use `johnrengelman.shadow` plugin and avoid embed paper API.